### PR TITLE
Fixes: avoid deploying latest tags and rename _SHA builtins to reflect skaffold nomenclature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - Feb xx, 2023
+## [0.2.0] - Feb 23, 2023
 
 ### Added
 
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - renamd the repo to gcp-cloud-deploy-extensions
 - update fastapi to patch Starlette security vulnerability: https://github.com/computeclub/gcp-cloud-deploy-extensions/security/dependabot/2
 - refactored image-tagger for readability/testability
+- nginx-app demo app now uses the cloudbuild `BUILD_ID` as the image tag passed when creating a release. This makes for deterministic releases.
 
 ## [0.1.1] - Feb 01, 2023
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Deploy also lacks some features and functionality of established CI/CD tools
 post-deploy image tagging, etc.) but instead gives extension points via
 [PubSub extensions](https://cloud.google.com/deploy/docs/subscribe-deploy-extensions)
 to flexibly fill these gaps. The extension solutions here stand up infrastructure
-and services necessary to build on top of that extension platform.
+and services necessary to build on top of that extensible platform.
 
 ## Architecture
 
 The extension recipes here follow a very similar deployment pattern to the solutions
-in cloud-builders-community and cloud-build-extensions. Namely, source code,
+in cloud-builders-community and cloud-build-notifiers. Namely, source code,
 dockerfiles, and cloudbuild configurations are packaged for users to build, store,
 and deploy container images to their GCP projects.
 
@@ -35,7 +35,7 @@ to manage all dependent infra.
 In either case, including an example of the variable inputs in an `example.tfvars`
 file is a simple way to guide extension consumers on how to run this terraform.
 
-## Per Pipeline extension configuration
+## Per-pipeline extension configuration
 
 Once deployed, extensions are configured via workload deploy pipelines that opt-in
 to using them. Following a kubernetes-style configuration approach, each extension
@@ -47,7 +47,7 @@ This secret should contain configuration values that the extension unpacks durin
 an execution. This is a powerful pattern for a few reasons:
 
 1. It's secure - some extensions will require secret data, others won't necessarily, but it's a good practice to treat all configuration as potentially sensitive and RBAC controlled.
-2. Extensions can be liberally deployed without affecting existing deploy pipelines - enabling a extension requires an annotation on opting-in deployment pipelines and the configuration in secret manager.
+2. Extensions can be liberally deployed without affecting existing pipelines - enabling a extension requires an annotation on opting-in deployment pipelines and the configuration in secret manager.
 
 ## Deploy extension index
 

--- a/demo/nginx-app/cloudbuild.yaml
+++ b/demo/nginx-app/cloudbuild.yaml
@@ -4,6 +4,7 @@ steps:
     args:
       [
         "--destination=${_REGISTRY_REPO_URL}/${_APP_NAME}:latest",
+        "--destination=${_REGISTRY_REPO_URL}/${_APP_NAME}:${BUILD_ID}",
         "--cache=true",
         "--log-format=text",
         "--cache-ttl=24h",
@@ -19,10 +20,10 @@ steps:
         "create",
         "release-${_EPOCH}",
         "--project=${PROJECT_ID}",
-        '--annotations="COMMIT_SHA=${COMMIT_SHA}"',
+        "--annotations=COMMIT_SHA=${COMMIT_SHA},BUILD_ID=${BUILD_ID}",
         "--region=us-central1",
         "--delivery-pipeline=nginx-app",
-        "--images=${_REGISTRY_REPO_URL}/${_APP_NAME}=${_REGISTRY_REPO_URL}/${_APP_NAME}:latest",
+        "--images=${_REGISTRY_REPO_URL}/${_APP_NAME}=${_REGISTRY_REPO_URL}/${_APP_NAME}:${BUILD_ID}",
       ]
 
 substitutions:

--- a/demo/nginx-app/kustomize/bases/knative_service.yaml
+++ b/demo/nginx-app/kustomize/bases/knative_service.yaml
@@ -19,7 +19,7 @@ spec:
       containerConcurrency: 1
       timeoutSeconds: 3600
       containers:
-        - image: us-docker.pkg.dev/bf-infra-tooling-xyz/demo/nginx-app:latest
+        - image: us-docker.pkg.dev/bf-infra-tooling-xyz/demo/nginx-app
           ports:
             - name: http1
               containerPort: 80

--- a/demo/nginx-app/skaffold.yaml
+++ b/demo/nginx-app/skaffold.yaml
@@ -7,6 +7,8 @@ build:
   googleCloudBuild:
     projectId: bf-infra-tooling-xyz
     serviceAccount: projects/bf-infra-tooling-xyz/serviceAccounts/dev-deployer@bf-infra-tooling-xyz.iam.gserviceaccount.com
+  tagPolicy:
+    inputDigest: {}
   artifacts:
     - image: us-docker.pkg.dev/bf-infra-tooling-xyz/demo/nginx-app
       kaniko:

--- a/extensions/image-tagger/README.md
+++ b/extensions/image-tagger/README.md
@@ -8,13 +8,13 @@ As an engineer, I want a successful rollout to an environment target to result
 in tags being added to the successfully deployed container image in a registry.
 A moving tag of `<ENV>-current` gives an at-a-glance view of what is currently
 deployed where when looking at a list of images in the registry. Likewise, tags
-having `<ENV>-<SHORT_SHA>` provide a historical record of what was previously
+having `<ENV>-<SHORT_DIGEST>` provide a historical record of what was previously
 deployed successfully to a target.
 
 ## Configuration schema
 
 `enabled` - a boolean that enables or disables the extension. If not present the extension is disabled.
-`tags` (optional) - the set of tags to apply to all successful deployments. If not specified, both "${ENVIRONMENT}-${SHORT_SHA}", and "${ENVIRONMENT}-current" will be used.
+`tag_templates`- the set of tag templates to apply to all successful deployments.
 
 Example:
 
@@ -23,7 +23,8 @@ Example:
     "enabled": true,
     "tag_templates": [
         "${ENVIRONMENT}-current",
-        "${ENVIRONMENT}-${SHORT_SHA}"
+        "${ENVIRONMENT}-${SHORT_DIGEST}",
+        "${ENVIRONMENT}-${FULL_DIGEST}"
     ]
 }
 ```
@@ -40,20 +41,5 @@ emitted.
 Certain template variable values are always available and can't be overridden by
 target labels. For now those are:
 
-`SHORT_SHA` - the annotated 8 byte hash of the container image.
-`FULL_SHA` - the full 40 byte hash of the container image.
-
-## Author's confessional
-
-### latest tags
-
-It's fairly well established that deploying the `latest` tag of a container image
-is not a best practice since container image tags are mutable. The examples in
-this repo create manifests that render and deploy `latest` images to Cloud Run
-environments, making a extension like this more necessary. If that gap can be
-closed via skaffold (e.g. if skaffold can create and use `<ENV>-<SHORT_SHA>`
-tags), that would be a more ideal starting point than rendering manifests that
-reference `latest` images. Even if skaffold closes that gap the solution here is
-valuable because tagging after a deployment is validated is useful (i.e. it
-creates a trail of deployed artifacts in a registry) and not otherwise achievable
-without custom tooling.
+`SHORT_DIGEST` - the annotated 12 byte hash of the container image.
+`FULL_DIGEST` - the full 40 byte hash of the container image.

--- a/extensions/image-tagger/src/extension.py
+++ b/extensions/image-tagger/src/extension.py
@@ -65,8 +65,8 @@ class Extension(BaseExtension):
 
         target_annotations: Dict[str, str] = dict(target.annotations)
         replacements = target_annotations.copy()
-        replacements["LONG_SHA"] = image.uri.split("@")[-1].split(":")[1]
-        replacements["SHORT_SHA"] = replacements["LONG_SHA"][0:8]
+        replacements["FULL_DIGEST"] = image.uri.split("@")[-1].split(":")[1]
+        replacements["SHORT_DIGEST"] = replacements["FULL_DIGEST"][0:12]
 
         tag_set = self.render_tag_set(
             replacements=replacements,


### PR DESCRIPTION
## What is this change?

One bugfix and a minor change.

The bugfix has the nginx-app example in demo build images that now tag with `BUILD_ID` instead of `latest`. This tag is passed to the `gcloud deploy release create` command which becomes the build artifact used throughout the release.

The minor change is a renaming of the built-in substitutions used by image-tagger. Previously these were `SHORT_SHA` and `FULL_SHA`. These are now `SHORT_DIGEST` and `FULL_DIGEST`.

## Why make this change?

The bugfix was important to resolve because releases were indeterminate under the previous scheme. If a latest build is created (e.g. a build and dev deployment) while other releases were still pending (e.g. a production release needing approval), the image having the tag `latest` would be used for the production release. This is a problem because the release to production must be deterministic and not just whatever image happens to have the `latest` tag at a given moment.

The minor change is to better align with skaffold nomenclature. One is more likely to understand that these `_DIGEST`s are not related to git SHAs if they're named this way.

## Links

None.